### PR TITLE
deps: update minitest and bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     coderay (1.1.3)
     diff-lcs (1.4.4)
     method_source (1.0.0)
-    minitest (5.14.4)
+    minitest (5.24.1)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -33,4 +33,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.1.4
+   2.5.15


### PR DESCRIPTION
this gets rid of a myriad warning when ran on newer rubies